### PR TITLE
Xcode 8 compatibility

### DIFF
--- a/mas-cli.xcodeproj/project.pbxproj
+++ b/mas-cli.xcodeproj/project.pbxproj
@@ -479,6 +479,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mphys.mas-cli";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "mas-cli/mas-cli-Bridging-Header.h";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -498,6 +499,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "mas-cli/mas-cli-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
By default, Xcode 8 requires the project to be written in Swift 3. However, Xcode 8 is still in beta, so it might be a better idea to enable the «Use Legacy Swift Language Version» option to make it working in Xcode 8 rather than converting the source to Swift 3.