### PR TITLE
Fix thoughtbot/Curry version in Seedfile

### DIFF
--- a/Seedfile
+++ b/Seedfile
@@ -1,3 +1,3 @@
-github "thoughtbot/Curry", "master", :files => "Source/Curry.swift"
+github "thoughtbot/Curry", "v2.3.3", :files => "Source/Curry.swift"
 github "Carthage/Commandant", "0.10.0", :files => "Sources/Commandant/*.swift"
 github "antitypical/Result", "2.0.0", :files => "Result/*.swift"


### PR DESCRIPTION
Downloading a specific release of Curry prevents unexpected breaks due to changes being made in the master branch of that project.