### PR TITLE
Fix #28: install multiple apps at once

### DIFF
--- a/mas-cli/Commands/Install.swift
+++ b/mas-cli/Commands/Install.swift
@@ -12,13 +12,27 @@ struct InstallCommand: CommandType {
     let function = "Install from the Mac App Store"
     
     func run(options: Options) -> Result<(), MASError> {
-        for id in options.appIds {
+        // Try to download applications with given identifiers and collect results
+        let results = options.appIds.map { (id) -> Result<(), MASError> in
             if let error = download(id) {
                 return .Failure(error)
+            } else {
+                return .Success()
             }
         }
-
-        return .Success(())
+        // See if at least one of the downloads failed
+        let errorIndex = results.indexOf {
+            if case .Failure(_) = $0 {
+                return true
+            }
+            return false
+        }
+        // And return an overrall general failure if there're failed downloads
+        if let _ = errorIndex {
+            return .Failure(MASError(code: .DownloadFailed))
+        } else {
+            return .Success()
+        }
     }
 }
 

--- a/mas-cli/Commands/Install.swift
+++ b/mas-cli/Commands/Install.swift
@@ -12,23 +12,25 @@ struct InstallCommand: CommandType {
     let function = "Install from the Mac App Store"
     
     func run(options: Options) -> Result<(), MASError> {
-        if let error = download(options.appId) {
-            return .Failure(error)
+        for id in options.appIds {
+            if let error = download(id) {
+                return .Failure(error)
+            }
         }
-        
+
         return .Success(())
     }
 }
 
 struct InstallOptions: OptionsType {
-    let appId: UInt64
+    let appIds: [UInt64]
     
-    static func create(appId: Int) -> InstallOptions {
-        return InstallOptions(appId: UInt64(appId))
+    static func create(appIds: [Int]) -> InstallOptions {
+        return InstallOptions(appIds: appIds.map{UInt64($0)})
     }
     
     static func evaluate(m: CommandMode) -> Result<InstallOptions, CommandantError<MASError>> {
         return create
-            <*> m <| Argument(usage: "the app ID to install")
+            <*> m <| Argument(usage: "the list of app IDs to install")
     }
 }


### PR DESCRIPTION
The fix was pretty straightforward (accept multiple arguments and call `download()` for each ID) except for one interesting caveat:

Since we add a new download observer every time we start downloading a new purchase, we also have to remove it when the download finishes.
Otherwise there will be *multiple* observers reporting download progress for *the same* purchase (i.e. user will see duplicate output).